### PR TITLE
feat: add updateLibraryFileContent

### DIFF
--- a/src/methods/nft/types.ts
+++ b/src/methods/nft/types.ts
@@ -38,6 +38,7 @@ export type StageFile = {
   webUrl?: string;
   immutable?: boolean;
   isNewLibrary?: boolean;
+  metadata?: MetadataClass;
 };
 export type StageConfigArgs = {
   environment?: string;


### PR DESCRIPTION
The `updateLibraryFileContent` method will take `tokenId`, `libraryId` and `file` as arguments, updating the content of the file alongside with the `size`, `content_type` and `content_hash` in metadata for that library.